### PR TITLE
Add NovaChain Mainnet and EVM Sidechain

### DIFF
--- a/_data/chains/eip155-6996.json
+++ b/_data/chains/eip155-6996.json
@@ -1,0 +1,24 @@
+{
+  "name": "NovaChain Mainnet",
+  "chain": "NOVA",
+  "rpc": [
+    "https://backend.nova-chain.io"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "NovaAction Coin",
+    "symbol": "NAC",
+    "decimals": 18
+  },
+  "infoURL": "https://nova-chain.io",
+  "shortName": "nova",
+  "chainId": 6996,
+  "networkId": 6996,
+  "explorers": [
+    {
+      "name": "NovaChain Explorer",
+      "url": "https://nova-chain.io/explorer",
+      "standard": "none"
+    }
+  ]
+}

--- a/_data/chains/eip155-96969.json
+++ b/_data/chains/eip155-96969.json
@@ -1,0 +1,28 @@
+{
+  "name": "NovaChain EVM Sidechain",
+  "chain": "NOVA",
+  "rpc": [
+    "https://evm.nova-chain.io"
+  ],
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Wrapped NovaAction Coin",
+    "symbol": "wNAC",
+    "decimals": 18
+  },
+  "infoURL": "https://nova-chain.io",
+  "shortName": "nova-evm",
+  "chainId": 96969,
+  "networkId": 96969,
+  "explorers": [
+    {
+      "name": "NovaChain Explorer",
+      "url": "https://nova-chain.io/explorer",
+      "standard": "EIP3091"
+    }
+  ],
+  "parent": {
+    "type": "L2",
+    "chain": "eip155-6996"
+  }
+}


### PR DESCRIPTION
Add NovaChain dual-chain system to Chainlist:

- NovaChain Mainnet (Chain ID: 6996) UTXO-based Proof of Action blockchain Native token: NAC RPC: https://backend.nova-chain.io

- NovaChain EVM Sidechain (Chain ID: 96969) EVM-compatible L2 using Besu/QBFT Wrapped token: wNAC RPC: https://evm.nova-chain.io Parent chain: eip155-6996

Both chains are operational and publicly accessible. Website: https://nova-chain.io
GitHub: https://github.com/Joe69Ham/NovaChain
Explorer : https://nova-chain.io/explorer